### PR TITLE
Add support for flow tests and kill camelCase

### DIFF
--- a/data/dns_grid_test.yaml
+++ b/data/dns_grid_test.yaml
@@ -1,19 +1,18 @@
 test:
-  name: dns AAAA
   type: dns_grid
   period: 600
-  servers: [1.1.1.1, 8.8.8.8]
+  health_settings:
+    dns_valid_codes: [0]
   record_type: DNS_RECORD_AAAA
-  healthSettings:
-    dnsValidCodes: [0]
+  servers: [1.1.1.1, 8.8.8.8]
 
 targets:
   use:
-    - www.example.com
-    - api.kentik.com
+  - www.example.com
+  - api.kentik.com
 
 agents:
   min_matches: 3
   match:
-    - name: regex(.*-west-.*)
-    - type: global
+  - name: regex(.*-west-.*)
+  - type: global

--- a/data/flow_test.yaml
+++ b/data/flow_test.yaml
@@ -1,0 +1,26 @@
+test:
+  type: flow
+  period: 600
+  protocol: tcp
+  target_type: city
+  direction: dst
+  inet_direction: src
+  max_tasks: 3
+  ping:
+    protocol: icmp
+    timeout: 3000
+  trace:
+    protocol: icmp
+    timeout: 22500
+
+targets:
+  use:
+  - Prague
+
+agents:
+  match:
+  - type: global
+  - any:
+    - country: US
+    - country: United States
+  max_matches: 2

--- a/data/hostname_test.yaml
+++ b/data/hostname_test.yaml
@@ -2,17 +2,19 @@ test:
   type: hostname
   period: 300
   ping:
-    timeout: 3000 # milliseconds
     protocol: icmp
+    timeout: 3000
   trace:
-    timeout: 22500 # milliseconds
     protocol: icmp
+    timeout: 22500
 
 targets:
   use:
-    - www.example.com
+  - www.example.com
 
 agents:
   match:
-    - family: IP_FAMILY_DUAL
-    - one_of_each: { asn: [14061], country: [US, DE] }
+  - family: IP_FAMILY_DUAL
+  - one_of_each:
+      asn: [14061]
+      country: [US, DE]

--- a/data/ip_test.yaml
+++ b/data/ip_test.yaml
@@ -1,17 +1,16 @@
 test:
-  name: knock on www.example.com
   type: ip
   period: 600
   ping:
-    timeout: 3000 # milliseconds
-    protocol: tcp
     port: 80
+    protocol: tcp
+    timeout: 3000
 
 targets:
   use:
-    - 2606:2800:220:1:248:1893:25c8:1946
-    - 93.184.216.34
+  - 2606:2800:220:1:248:1893:25c8:1946
+  - 93.184.216.34
 
 agents:
   use:
-    - 606
+  - 606

--- a/data/mesh_test.yaml
+++ b/data/mesh_test.yaml
@@ -1,23 +1,20 @@
 test:
-  name: Digital Ocean mesh
   type: mesh
-  period: 600
-  tasks: [ping, traceroute]
   family: IP_FAMILY_V4
+  period: 600
   ping:
-    timeout: 3000 # milliseconds
     protocol: icmp
+    timeout: 3000
   trace:
-    timeout: 22500 # milliseconds
     protocol: icmp
-  healthSettings:
-    latencyCriticalStddev: 4
-    packetLossWarning: 20
-  headers:
-    user-agent: kentik
+    timeout: 22500
+  health_settings:
+    latency_critical_stddev: 4
+    packet_loss_warning: 20
 
 agents:
   match:
-    - family: IP_FAMILY_DUAL
-    - one_of_each: { asn: [14061], country: [US, DE, SG] }
-
+  - family: IP_FAMILY_DUAL
+  - one_of_each:
+      asn: [14061]
+      country: [US, DE, SG]

--- a/data/network_grid_test.yaml
+++ b/data/network_grid_test.yaml
@@ -1,21 +1,21 @@
 test:
-  type: network_grid
   period: 300
+  type: network_grid
 
 targets:
   match:
     devices:
-      - site.site_name: Ashburn DC3
-      - label: one_of(edge router, gateway, bastions)
+    - site.site_name: Ashburn DC3
+    - label: one_of(edge router, gateway, bastions)
     interface_addresses:
       family: IP_FAMILY_V4
-      public_only: True
+      public_only: true
     sending_ips:
-      public_only: True
+      public_only: true
     snmp_ip:
-      public_only: True
+      public_only: true
 
 agents:
   match:
-    - family: IP_FAMILY_DUAL
-    - one_of_each: { asn: [15169, 7224, 16509, 36351], country: [US, AU, BR] }
+  - type: private
+

--- a/data/page_load_test.yaml
+++ b/data/page_load_test.yaml
@@ -1,31 +1,33 @@
 test:
   type: page_load
   period: 600
-  protocol: tcp
   ping:
-    timeout: 3000 # milliseconds
     protocol: icmp
+    timeout: 3000
+  protocol: tcp
   trace:
-    timeout: 22500 # milliseconds
     protocol: icmp
-  healthSettings:
-    latencyCriticalStddev: 3
-    latencyWarningStddev: 1
-    packetLossCritical: 50
-    packetLossWarning: 20
-    httpLatencyCriticalStddev: 3
-    httpLatencyWarningStddev: 1
-    httpValidCodes: [200, 301]
+    timeout: 22500
   headers:
     user-agent: kentik
+  health_settings:
+    http_latency_critical_stddev: 3
+    http_latency_warning_stddev: 1
+    http_valid_codes: [200, 301]
+    latency_critical_stddev: 3
+    latency_warning_stddev: 1
+    packet_loss_critical: 50
+    packet_loss_warning: 20
 
 targets:
   use:
-    - https://www.example.com
+  - https://www.example.com
 
 agents:
   match:
-    - any:
-      - family: IP_FAMILY_V4
-      - family: IP_FAMILY_DUAL
-    - one_of_each: { asn: [31898, 16509], country: [United States, US] }
+  - any:
+    - family: IP_FAMILY_V4
+    - family: IP_FAMILY_DUAL
+  - one_of_each:
+      asn: [31898, 16509]
+      country: [United States, US]

--- a/data/url_test.yaml
+++ b/data/url_test.yaml
@@ -1,29 +1,27 @@
 test:
   type: url
   period: 600
-  protocol: tcp
   ping:
-    timeout: 3000 # milliseconds
     protocol: icmp
+    timeout: 3000
   trace:
-    timeout: 22500 # milliseconds
     protocol: icmp
-  healthSettings:
-    latencyCriticalStddev: 3
-    latencyWarningStddev: 1
-    packetLossCritical: 50
-    packetLossWarning: 20
-    httpLatencyCriticalStddev: 3
-    httpLatencyWarningStddev: 1
-    httpValidCodes: [200, 301]
+    timeout: 22500
   headers:
     user-agent: kentik
+  health_settings:
+    http_latency_critical_stddev: 3
+    http_latency_warning_stddev: 1
+    http_valid_codes: [200, 301]
+    latency_critical_stddev: 3
+    latency_warning_stddev: 1
+    packet_loss_critical: 50
+    packet_loss_warning: 20
 
 targets:
   use:
-    - https://www.example.com
+  - https://www.squarespace.com
 
 agents:
-  max_matches: 2
   match:
-    - any: [ country: US, country: United States ]
+    - type: private

--- a/kentik_synth_client/synth_tests.py
+++ b/kentik_synth_client/synth_tests.py
@@ -383,7 +383,7 @@ class FlowTest(PingTraceTest):
         name: str,
         target: str,
         agent_ids: List[str],
-        type: FlowTestSubType,
+        target_type: FlowTestSubType,
         direction: DirectionType,
         inet_direction: DirectionType,
         max_tasks: int = 5,
@@ -395,7 +395,7 @@ class FlowTest(PingTraceTest):
                 agentIds=agent_ids,
                 flow=dict(
                     target=target,
-                    type=type,
+                    type=target_type,
                     direction=direction,
                     inetDirection=inet_direction,
                     maxTasks=max_tasks,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 grpcio
+inflection
 kentik-api >= 0.3.0
 pyyaml
 typer

--- a/synth_tools/__init__.py
+++ b/synth_tools/__init__.py
@@ -1,0 +1,4 @@
+import logging
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger()

--- a/synth_tools/cli.py
+++ b/synth_tools/cli.py
@@ -3,9 +3,10 @@ from typing import Optional
 
 import typer
 
+from synth_tools import log
 from synth_tools.apis import APIs
-from synth_tools.commands import commands_registry, log
-from synth_tools.commands.utils import fail
+from synth_tools.commands import commands_registry
+from synth_tools.utils import fail
 
 app = typer.Typer()
 

--- a/synth_tools/commands/__init__.py
+++ b/synth_tools/commands/__init__.py
@@ -1,9 +1,3 @@
-import logging
-
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger()
-
-
 from synth_tools.commands.agents import agents_app
 from synth_tools.commands.tests import tests_app
 

--- a/synth_tools/commands/agents.py
+++ b/synth_tools/commands/agents.py
@@ -3,7 +3,8 @@ from typing import List, Optional
 import typer
 
 from kentik_synth_client import KentikAPIRequestError, KentikSynthClient
-from synth_tools.commands.utils import all_matcher_from_rules, fail, get_api, print_agent, print_agent_brief
+from synth_tools.matchers import all_matcher_from_rules
+from synth_tools.utils import fail, get_api, print_agent, print_agent_brief
 
 agents_app = typer.Typer()
 

--- a/synth_tools/commands/tests.py
+++ b/synth_tools/commands/tests.py
@@ -5,8 +5,9 @@ import typer
 
 from kentik_synth_client import KentikAPIRequestError, KentikSynthClient, TestStatus
 from kentik_synth_client.synth_tests import SynTest
-from synth_tools.commands.utils import all_matcher_from_rules, fail, get_api, print_health, print_test, print_test_brief
 from synth_tools.core import load_test, run_one_shot
+from synth_tools.matchers import all_matcher_from_rules
+from synth_tools.utils import fail, get_api, print_health, print_test, print_test_brief
 
 tests_app = typer.Typer()
 

--- a/synth_tools/core.py
+++ b/synth_tools/core.py
@@ -1,6 +1,4 @@
 import logging
-import random
-import string
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from time import sleep
@@ -17,10 +15,6 @@ log = logging.getLogger("core")
 
 def _fail(msg: str) -> None:
     raise RuntimeError(msg)
-
-
-def random_string(str_size, allowed_chars=string.ascii_letters + string.digits):
-    return "".join(random.choice(allowed_chars) for _ in range(str_size))
 
 
 def run_one_shot(


### PR DESCRIPTION
Includes:
- getting rid of camelCase in any user input and output, i.e.:
  - test/agent configs are shown in snake_case
  - test config files use snake_case
  - match rules in test/agent match commansd refer to properties with snake_case names
- make the 'contains' match function to work with integers
- refactoring of loading of test type specific attributes
- moving utils.py to synth_tools root
- moving functions from utils to matches in order to avoid circular imports
- removal of unused code
