### PR TITLE
Create and modify times for test, one-shot test cleanup

### DIFF
--- a/synth_tools/commands/tests.py
+++ b/synth_tools/commands/tests.py
@@ -7,7 +7,7 @@ from kentik_synth_client import KentikAPIRequestError, KentikSynthClient, TestSt
 from kentik_synth_client.synth_tests import SynTest
 from synth_tools.core import load_test, run_one_shot
 from synth_tools.matchers import all_matcher_from_rules
-from synth_tools.utils import fail, get_api, print_health, print_test, print_test_brief
+from synth_tools.utils import fail, get_api, print_health, print_test, print_test_brief, test_to_dict
 
 tests_app = typer.Typer()
 
@@ -146,7 +146,7 @@ def match_test(
     """
     api = get_api(ctx)
     matcher = all_matcher_from_rules(rules)
-    matching = [t for t in api.syn.tests if matcher.match(t.to_dict()["test"])]
+    matching = [t for t in api.syn.tests if matcher.match(test_to_dict(t))]
     if not matching:
         typer.echo("No test matches specified rules")
     else:

--- a/synth_tools/matchers.py
+++ b/synth_tools/matchers.py
@@ -201,6 +201,9 @@ class PropertyMatcher(Matcher):
         else:
             try:
                 self.value = datetime.fromisoformat(arg)
+                if not self.value.tzinfo:
+                    log.debug("Setting timezone to UTC for match time '%s'", self.value.isoformat())
+                    self.value = self.value.replace(tzinfo=timezone.utc)
             except ValueError as exc:
                 log.error("%s: Invalid timestamp in configuration: %s", self.__class__.__name__, exc)
                 self.value = None

--- a/synth_tools/utils.py
+++ b/synth_tools/utils.py
@@ -138,13 +138,20 @@ INTERNAL_TEST_SETTINGS = (
 )
 
 
+def test_to_dict(test: SynTest) -> Dict[str, Any]:
+    d = test.to_dict()["test"]
+    d["created"] = test.cdate
+    d["modified"] = test.edate
+    return d
+
+
 def print_test(
     test: SynTest,
     indent_level: int = 0,
     show_all: bool = False,
     attributes: Optional[str] = None,
 ) -> None:
-    d = test.to_dict()["test"]
+    d = test_to_dict(test)
     if not show_all:
         if not test.deployed:
             del d["status"]


### PR DESCRIPTION
Show create and modify times for tests
Allow mathching tests on create and modify
Add UTC timezone to time match values (if not specified explicitly)
Remove one-shot test if the process is terminated prematurely
Do not subtract test creation time from initial wait on one-shot test results