### PR TITLE
Make one-shot retrieve longest possible result period 

### DIFF
--- a/synth_tools/core.py
+++ b/synth_tools/core.py
@@ -75,7 +75,7 @@ def run_one_shot(
         try:
             health = api.syn.health(
                 [t.id],
-                start=now - timedelta(seconds=t.max_period * wait_factor),
+                start=min(start, now - timedelta(seconds=t.max_period * wait_factor)),
                 end=now,
             )
         except KentikAPIRequestError as ex:
@@ -103,7 +103,7 @@ def run_one_shot(
         )
         break
     else:
-        log.fatal("Failed to get valid health data for test id: %s", t.id)
+        log.debug("Failed to get valid health data for test id: %s", t.id)
         health = None
 
     if delete:

--- a/synth_tools/utils.py
+++ b/synth_tools/utils.py
@@ -99,7 +99,10 @@ def print_health(
                     continue
                 for task_type in ("ping", "knock", "shake", "dns", "http"):
                     if task_type in task["task"]:
-                        target = task["task"][task_type]["target"]
+                        if task_type == "dns":
+                            target = f"{task['task'][task_type]['target']} via {task['task'][task_type]['resolver']}"
+                        else:
+                            target = task["task"][task_type]["target"]
                         break
                 else:
                     target = h["dstIp"]


### PR DESCRIPTION
One-shot test now always retrieves test results from the start of execution to the time of health request
Results for DNS tests now include the server/resolver in target key