### PR TITLE
Test print improvements

### DIFF
--- a/kentik_synth_client/synth_tests.py
+++ b/kentik_synth_client/synth_tests.py
@@ -215,11 +215,13 @@ class SynTest(_ConfigElement):
             return None
 
     @property
-    def created_by(self) -> str:
+    def created_by(self) -> Optional[str]:
+        if all(not x for x in (self._createdBy.__dict__.values())):
+            return None
         if self._createdBy.fullName:
-            return f"{self._createdBy.fullName} id: {self._createdBy.id} e-mail: {self._createdBy.email}"
+            return f"{self._createdBy.fullName} user_id: {self._createdBy.id} e-mail: {self._createdBy.email}"
         else:
-            return f"id: {self._createdBy.id} e-mail: {self._createdBy.email}"
+            return f"user_id: {self._createdBy.id} e-mail: {self._createdBy.email}"
 
     @property
     def max_period(self) -> int:

--- a/synth_tools/commands/tests.py
+++ b/synth_tools/commands/tests.py
@@ -152,8 +152,11 @@ def get_test(
     Print test configuration
     """
     api = get_api(ctx)
+    print_id = len(test_ids) > 1 and (not fields or "id" not in fields.split(","))
     for i in test_ids:
         t = _get_test_by_id(api.syn, i)
+        if print_id:
+            typer.echo(f"id: {t.id}")
         print_test(t, show_all=show_all, attributes=fields)
 
 

--- a/synth_tools/utils.py
+++ b/synth_tools/utils.py
@@ -107,9 +107,11 @@ INTERNAL_TEST_SETTINGS = (
 
 def test_to_dict(test: SynTest) -> Dict[str, Any]:
     d = test.to_dict()["test"]
+    d["id"] = test.id
     d["created"] = test.cdate
     d["modified"] = test.edate
-    d["created_by"] = test.created_by
+    if test.created_by:
+        d["created_by"] = test.created_by
     return d
 
 


### PR DESCRIPTION
Do not print created_by if not provided in API response
Print test id when explicitly requested
Allow matching on test id