### PR TITLE
Add support for text substitutions to test one-shot command

### DIFF
--- a/kentik_synth_client/synth_tests.py
+++ b/kentik_synth_client/synth_tests.py
@@ -114,6 +114,9 @@ class _DefaultList(list):
         for v in self._values:
             self.append(v)
 
+    def to_dict(self):
+        return list(self._values)
+
 
 class DefaultHTTPValidCodes(_DefaultList):
     _values = (200, 201)


### PR DESCRIPTION
Also includes:
- refactoring parsing of substitutions string
- formatting of task list in text config output