### PR TITLE
Remove `--show-all` option from all commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,18 +542,16 @@ Arguments:
 Options:
   --retries INTEGER               Number retries waiting for test results
                                   [default: 3]
-  --raw-out TEXT                  Path to file to store raw test results in
-                                  JSON format
-  --failing / --no-failing        Print only failing results  [default: no-
-                                  failing]
+  --summary / --no-summary        Print summary rest results  [default: no-
+                                  summary]
   --delete / --no-delete          Delete test after retrieving results
                                   [default: delete]
   --print-config / --no-print-config
                                   Print test configuration  [default: no-
                                   print-config]
-  --show-all / --no-show-all      Show all test attributes  [default: no-show-
-                                  all]
-  --json                          Print output in JSON format
+  --json-out TEXT                 Path to store test results in JSON format
+  -s, --substitute TEXT           Comma separated list of substitutions in the
+                                  form of 'var:value'
   --help                          Show this message and exit.
 ```
 

--- a/synth_tools/core.py
+++ b/synth_tools/core.py
@@ -61,7 +61,7 @@ class TestResults:
     def set_results(self, results: List[Dict[str, Any]]):
         def _metric_data(m: str, d: Dict[str, Any]) -> str:
             unit = ""
-            factor = 1
+            factor = 1.0
             if m == "packet_loss":
                 unit = "%"
                 factor = 100.0
@@ -104,11 +104,13 @@ class TestResults:
                         if task_type in task:
                             break
                     else:
-                        log.error("No data for any of test tasks (%s) in results", ",".join(self.test.configured_tasks))
+                        log.error(
+                            "No data for any of test tasks (%s) in results", ",".join(self.test.configured_tasks)
+                        )  # type: ignore
                         continue
                     td = task[task_type]
                     if not td["target"]:
-                        td["target"] = ",".join(self.test.targets)
+                        td["target"] = ",".join(self.test.targets)  # type: ignore
                     if "server" in td:
                         target = f"{td['target']} via {td['server']}"
                     elif "dst_ip" in td:

--- a/synth_tools/test_factory.py
+++ b/synth_tools/test_factory.py
@@ -312,10 +312,10 @@ def _get_agents(
 
     min_agents = cfg.get("min_matches", 1)
     max_agents = cfg.get("max_matches")
-    cfg = cfg["match"]
+    match_cfg: List[Dict[str, Any]] = cfg["match"]
     log.debug("_get_agents: match: %s (min: %d, max: %s)", cfg, min_agents, max_agents)
     try:
-        agents_matcher = AllMatcher(cfg, max_matches=max_agents, property_transformer=snake_to_camel)
+        agents_matcher = AllMatcher(match_cfg, max_matches=max_agents, property_transformer=snake_to_camel)
     except RuntimeError as exc:
         fail(f"Failed to parse agent match: {exc}")
         return set()  # to make linters happy (fail actually never returns)

--- a/synth_tools/utils.py
+++ b/synth_tools/utils.py
@@ -94,7 +94,7 @@ def dict_to_json(filename: str, data: Dict[str, Any]) -> None:
 
 
 def test_to_dict(test: SynTest) -> Dict[str, Any]:
-    d = dict(id=test.id)
+    d: Dict[str, Any] = dict(id=test.id)
     d.update(transform_dict_keys(test.to_dict()["test"], camel_to_snake))
     d["created"] = test.created
     d["modified"] = test.modified
@@ -107,11 +107,6 @@ NON_COMPARABLE_TEST_ATTRS = [
     "created",
     "modified",
     "created_by",
-]
-
-
-INTERNAL_TEST_SETTINGS = [
-    "tasks",
 ]
 
 
@@ -152,15 +147,12 @@ def _filter_test_attrs(t: dict, attrs: List[str]) -> None:
 def print_test(
     test: SynTest,
     indent_level: int = 0,
-    show_all: bool = False,
     attributes: Optional[str] = None,
     json_format=False,
 ) -> None:
     d = test_to_dict(test)
-    if not show_all:
-        if not test.deployed:
-            del d["status"]
-        _filter_test_attrs(d, INTERNAL_TEST_SETTINGS)
+    if not test.deployed:
+        del d["status"]
     if attributes:
         attr_list = attributes.split(",")
     else:
@@ -171,24 +163,20 @@ def print_test(
         print_struct(filter_dict(d, attr_list), indent_level=indent_level)
 
 
-def print_tests(
-    tests: List[SynTest], show_all: bool = False, attributes: Optional[str] = None, json_format=False
-) -> None:
+def print_tests(tests: List[SynTest], attributes: Optional[str] = None, json_format=False) -> None:
     if json_format:
         if attributes:
             attr_list = attributes.split(",")
         else:
             attr_list = []
-        out = []
+        out: List[Any] = []
         for t in sorted(tests, key=lambda x: sort_id(x.id)):
             if attributes == "id":
                 out.append(t.id)
             else:
                 d = test_to_dict(t)
-                if not show_all:
-                    if not t.deployed:
-                        del d["status"]
-                    _filter_test_attrs(d, INTERNAL_TEST_SETTINGS)
+                if not t.deployed:
+                    del d["status"]
                 out.append(filter_dict(d, attr_list))
         json.dump(out, sys.stdout, default=str, indent=2)
         typer.echo()
@@ -200,7 +188,7 @@ def print_tests(
             else:
                 if print_id:
                     typer.echo(f"id: {t.id}")
-                print_test(t, indent_level=1, show_all=show_all, attributes=attributes)
+                print_test(t, indent_level=1, attributes=attributes)
 
 
 def print_tests_brief(tests: List[SynTest]) -> None:
@@ -217,16 +205,15 @@ def _remove_unused_test_settings(test: dict):
             del test["settings"][cfg]
 
 
-def print_test_diff(first: SynTest, second: SynTest, show_all=False, labels: Tuple[str, str] = ("FIRST", "SECOND")):
+def print_test_diff(first: SynTest, second: SynTest, labels: Tuple[str, str] = ("FIRST", "SECOND")):
     f = transform_dict_keys(first.to_dict()["test"], camel_to_snake)
     s = transform_dict_keys(second.to_dict()["test"], camel_to_snake)
-    if not show_all:
-        del f["status"]
-        del s["status"]
-        _remove_unused_test_settings(f)
-        _remove_unused_test_settings(s)
-        _filter_test_attrs(f, INTERNAL_TEST_SETTINGS + NON_COMPARABLE_TEST_ATTRS)
-        _filter_test_attrs(s, INTERNAL_TEST_SETTINGS + NON_COMPARABLE_TEST_ATTRS)
+    del f["status"]
+    del s["status"]
+    _remove_unused_test_settings(f)
+    _remove_unused_test_settings(s)
+    _filter_test_attrs(f, NON_COMPARABLE_TEST_ATTRS)
+    _filter_test_attrs(s, NON_COMPARABLE_TEST_ATTRS)
     diffs = dict_compare(f, s)
     if diffs:
         table = Texttable(max_width=os.get_terminal_size()[0])


### PR DESCRIPTION
The only internal test config attribute `tasks` is now always displayed