### PR TITLE
Implemented `test import` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ This section specifies test attributes other than list of targets and agents.
 
 _Common test attributes:_
 
-  | name           | purpose                                                                       | required | possible values                                                 |
-  | :--------------| :-----------------------------------------------------------------------------| :--------| :---------------------------------------------------------------|
-  | type           | test type                                                                     | YES      | ip, hostname, network_grid, dns, dns_grid, url, page-load, mesh |
-  | name           | name of the test                                                              | NO       | any printable string                                            |
-  | period         | test execution period                                                         | NO       | integer (default: 60 seconds)                                   |
-  | family         | IP address family to use for tests selecting target address via DNS resolution| NO       | IP_FAMILY_DUAL (default), IP_FAMILY_V4, IP_FAMILY_V6            |
-  | health_settings| definition of thresholds for establishing test health                         | NO       | _see bellow_ (default: no thresholds)                           |
+  | name           | purpose                                                                       | required | possible values                                                         |
+  | :--------------| :-----------------------------------------------------------------------------| :--------| :-----------------------------------------------------------------------|
+  | type           | test type                                                                     | YES      | ip, hostname, network_grid, dns, dns_grid, url, page-load, network_mesh |
+  | name           | name of the test                                                              | NO       | any printable string                                                    |
+  | period         | test execution period                                                         | NO       | integer (default: 60 seconds)                                           |
+  | family         | IP address family to use for tests selecting target address via DNS resolution| NO       | IP_FAMILY_DUAL (default), IP_FAMILY_V4, IP_FAMILY_V6                    |
+  | health_settings| definition of thresholds for establishing test health                         | NO       | _see bellow_ (default: no thresholds)                                   |
 
 _Health settings attributes_
 ```
@@ -128,7 +128,7 @@ _Supported `targets` specification for individual test types_:
   | hostname, dns, dns_grid | `use: <list of DNS names>`                                      |
   | url, page_load          | `use: <list of URLs> `                                          |
   | agent                   | `use: <list of agent_ids>` or `match: <agent matching rules>`   |
-  | mesh                    | None (`targets` section is ignored)                             |                                             
+  | network_mesh            | None (`targets` section is ignored)                             |                                             
 
 **Address matching rules**
 
@@ -236,7 +236,7 @@ expanded to UTC time based on system time of the machine on which `synth_ctl` ex
 Maximum and minimum number of matched targets of agents  can be specified using:
 `max_matches: <MAX>` or `min_matches: <MIN>` directives in corresponding `targets` or `agents` section.
 If less than `min_targets` matches test creation fails. If more than `max_matches` targets or agents match only
-first `max_matches` objects are used. At least 1 agent is required for any test (except for `mesh`).
+first `max_matches` objects are used. At least 1 agent is required for any test (except for `network_mesh`).
 
 Example:
 ```yaml
@@ -377,7 +377,7 @@ id: 5228
 ❯ synth_ctl test match "settings.agentIds:contains(813)"
 id: 5372
   name: big one
-  type: application_mesh
+  type: network_mesh
   status: TEST_STATUS_ACTIVE
   settings:
     agent_ids: ['848', '598', '608', '849', '733', '2642', '2644', '828', '813', '803', '2122', '644', '1022', '662', '573', '612', '611', '615', '568', '616']

--- a/kentik_synth_client/synth_tests/__init__.py
+++ b/kentik_synth_client/synth_tests/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict
 
-from kentik_synth_client.types import TestType
+from kentik_synth_client.types import FlowTestSubType, TestType
 
 from .agent import AgentTest
 from .base import HealthSettings, PingTask, SynTest, TraceTask
@@ -10,7 +10,7 @@ from .dns_grid import DNSGridTest
 from .flow import FlowTest
 from .hostname import HostnameTest
 from .ip import IPTest
-from .mesh import MeshTest
+from .mesh import NetworkMeshTest
 from .network_grid import NetworkGridTest
 from .page_load import PageLoadTest
 from .url import UrlTest
@@ -29,7 +29,7 @@ def make_synth_test(d: Dict[str, Any]) -> SynTest:
             TestType.flow: FlowTest,
             TestType.hostname: HostnameTest,
             TestType.ip: IPTest,
-            TestType.mesh: MeshTest,
+            TestType.network_mesh: NetworkMeshTest,
             TestType.network_grid: NetworkGridTest,
             TestType.page_load: PageLoadTest,
             TestType.url: UrlTest,

--- a/kentik_synth_client/synth_tests/dns.py
+++ b/kentik_synth_client/synth_tests/dns.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Type, TypeVar
 
 from kentik_synth_client.types import *
 
-from .base import PingTask, SynTest, SynTestSettings, TraceTask
+from .base import SynTest, SynTestSettings
 
 
 @dataclass
@@ -32,14 +32,14 @@ class DNSTest(SynTest):
         servers: List[str],
         record_type: DNSRecordType = DNSRecordType.A,
         timeout: int = 5000,
-        server_port: int = 53,
+        port: int = 53,
     ) -> DNSTestType:
         return cls(
             name=name,
             settings=DNSTestSettings(
                 agentIds=agent_ids,
                 tasks=["dns"],
-                dns=dict(target=target, recordType=record_type, servers=servers, timeout=timeout, port=server_port),
+                dns=dict(target=target, recordType=record_type, servers=servers, timeout=timeout, port=port),
             ),
         )
 

--- a/kentik_synth_client/synth_tests/dns_grid.py
+++ b/kentik_synth_client/synth_tests/dns_grid.py
@@ -29,14 +29,14 @@ class DNSGridTest(SynTest):
         servers: List[str],
         record_type: DNSRecordType = DNSRecordType.A,
         timeout: int = 5000,
-        server_port: int = 53,
+        port: int = 53,
     ) -> DNSGridTestType:
         return cls(
             name=name,
             settings=DNSGridTestSettings(
                 agentIds=agent_ids,
                 tasks=["dns"],
-                dnsGrid=dict(target=target, recordType=record_type, servers=servers, timeout=timeout, port=server_port),
+                dnsGrid=dict(target=target, recordType=record_type, servers=servers, timeout=timeout, port=port),
             ),
         )
 

--- a/kentik_synth_client/synth_tests/flow.py
+++ b/kentik_synth_client/synth_tests/flow.py
@@ -31,7 +31,7 @@ class FlowTest(PingTraceTest):
         inet_direction: DirectionType,
         max_ip_targets: int = 10,
         max_providers: int = 3,
-        target_refresh_interval: int = 43200000,
+        target_refresh_interval_millis: int = 43200000,
     ) -> FlowTestType:
         return cls(
             name=name,
@@ -44,12 +44,7 @@ class FlowTest(PingTraceTest):
                     inetDirection=inet_direction,
                     maxIpTargets=max_ip_targets,
                     maxProviders=max_providers,
-                    targetRefreshIntervalMillis=target_refresh_interval,
+                    targetRefreshIntervalMillis=target_refresh_interval_millis,
                 ),
             ),
         )
-
-    @property
-    def targets(self) -> List[str]:
-        d = self.settings.flow
-        return [f"{d['direction']}:{d['type']}:{d['target']}"]

--- a/kentik_synth_client/synth_tests/ip.py
+++ b/kentik_synth_client/synth_tests/ip.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from ipaddress import ip_address
 from typing import List, Type, TypeVar
 
 from kentik_synth_client.types import *
@@ -21,4 +22,7 @@ class IPTest(PingTraceTest):
 
     @classmethod
     def create(cls: Type[IPTestType], name: str, targets: List[str], agent_ids: List[str]) -> IPTestType:
-        return cls(name=name, settings=IPTestSettings(agentIds=agent_ids, ip=dict(targets=targets)))
+        addresses = [ip_address(a) for a in targets]
+        return cls(
+            name=name, settings=IPTestSettings(agentIds=agent_ids, ip=dict(targets=[str(a) for a in sorted(addresses)]))
+        )

--- a/kentik_synth_client/synth_tests/mesh.py
+++ b/kentik_synth_client/synth_tests/mesh.py
@@ -5,17 +5,24 @@ from kentik_synth_client.types import *
 
 from .base import PingTraceTest, PingTraceTestSettings
 
-MeshTestType = TypeVar("MeshTestType", bound="MeshTest")
+
+@dataclass
+class NetworkMeshTestSettings(PingTraceTestSettings):
+    networkMesh: dict = field(default_factory=dict)
+
+
+NetworkMeshTestType = TypeVar("NetworkMeshTestType", bound="NetworkMeshTest")
 
 
 @dataclass
-class MeshTest(PingTraceTest):
-    type: TestType = field(init=False, default=TestType.mesh)
+class NetworkMeshTest(PingTraceTest):
+    type: TestType = field(init=False, default=TestType.network_mesh)
+    settings: NetworkMeshTestSettings = field(default_factory=NetworkMeshTestSettings)
 
     @classmethod
-    def create(cls: Type[MeshTestType], name: str, agent_ids: List[str]) -> MeshTestType:
-        return cls(name=name, settings=PingTraceTestSettings(agentIds=agent_ids))
-
-    @property
-    def targets(self) -> List[str]:
-        return self.settings.agentIds
+    def create(
+        cls: Type[NetworkMeshTestType], name: str, agent_ids: List[str], use_local_ip: bool = False
+    ) -> NetworkMeshTestType:
+        return cls(
+            name=name, settings=NetworkMeshTestSettings(agentIds=agent_ids, networkMesh=dict(useLocalIp=use_local_ip))
+        )

--- a/kentik_synth_client/synth_tests/network_grid.py
+++ b/kentik_synth_client/synth_tests/network_grid.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from ipaddress import ip_address
 from typing import List, Type, TypeVar
 
 from kentik_synth_client.types import *
@@ -23,4 +24,10 @@ class NetworkGridTest(PingTraceTest):
     def create(
         cls: Type[NetworkGridTestType], name: str, targets: List[str], agent_ids: List[str]
     ) -> NetworkGridTestType:
-        return cls(name=name, settings=GridTestSettings(agentIds=agent_ids, networkGrid=dict(targets=targets)))
+        addresses = [ip_address(a) for a in targets]
+        return cls(
+            name=name,
+            settings=GridTestSettings(
+                agentIds=agent_ids, networkGrid=dict(targets=[str(a) for a in sorted(addresses)])
+            ),
+        )

--- a/kentik_synth_client/types.py
+++ b/kentik_synth_client/types.py
@@ -19,7 +19,7 @@ class TestType(SerializableEnum):
     flow = "flow"
     hostname = "hostname"
     ip = "ip"
-    mesh = "network_mesh"
+    network_mesh = "network_mesh"
     network_grid = "network_grid"
     page_load = "page_load"
     url = "url"

--- a/synth_tools/commands/tests.py
+++ b/synth_tools/commands/tests.py
@@ -17,6 +17,7 @@ from synth_tools.utils import (
     get_api,
     print_struct,
     print_test,
+    print_test_config,
     print_test_diff,
     print_test_results,
     print_tests,
@@ -387,3 +388,17 @@ def get_test_trace(
         log.info("Writing trace data to %s", raw_out)
         dict_to_json(raw_out, trace)
     print_struct(trace)
+
+
+@tests_app.command("import")
+def import_test(
+    ctx: typer.Context,
+    test_id: str = typer.Argument(..., help="Id of the test to import"),
+) -> None:
+    """
+    Compare configurations of 2 existing tests
+    """
+    api = get_api(ctx)
+    test = _get_test_by_id(api.syn, test_id)
+    log.debug("test: %s", test)
+    print_test_config(test)

--- a/synth_tools/core.py
+++ b/synth_tools/core.py
@@ -104,9 +104,8 @@ class TestResults:
                         if task_type in task:
                             break
                     else:
-                        log.error(
-                            "No data for any of test tasks (%s) in results", ",".join(self.test.configured_tasks)
-                        )  # type: ignore
+                        tasks = ",".join(self.test.configured_tasks)  # type: ignore
+                        log.error("No data for any of test tasks (%s) in results", tasks)
                         continue
                     td = task[task_type]
                     if not td["target"]:


### PR DESCRIPTION
The command constructs test config YAML file based on config fetched from the API.

Also includes:
- changed `mesh` test type to `network_mesh` to match the UI
- renamed MeshTest to NetworkMeshTest
- added support for `network_mesh` specific config (`use_local_ip`)
- added validation of test period against set of allowed values
- fixed validation of URLs to allow numeric IP addresses
- added sorting of IP targets in `network_grid` and `ip` test
- improved robustness of config parsing
- added support for `port` attribute in `dns` and `dns_grid` tests
- renamed `flow` test attribute `target_refresh_interval` to `target_refresh_interval_millis` to fight less with the API