### PR TITLE
Don not retry requets after 504 errors

### DIFF
--- a/kentik_synth_client/api_transport_http.py
+++ b/kentik_synth_client/api_transport_http.py
@@ -41,7 +41,7 @@ class SynthHTTPTransport(KentikAPITransport):
             retry_strategy=Retry(
                 total=3,
                 backoff_factor=1,
-                status_forcelist=[429, 502, 503, 504],
+                status_forcelist=[429, 502, 503],
                 allowed_methods=["DELETE", "HEAD", "GET", "PUT", "OPTIONS", "PATCH", "POST"],
             ),
         ).query._api_connector._session


### PR DESCRIPTION
The most likely cause of Kentik API returning 504 is a deadline violation of gRPC request to the backend, which is in turn most likely caused by large response data. Retry cannot succeed in this situation and unnecessarily wastes resources.