### PR TITLE
Improve handling of matchers referring to non-existent property

### DIFF
--- a/data/dns_grid_test.yaml
+++ b/data/dns_grid_test.yaml
@@ -12,7 +12,7 @@ targets:
   - www.example.com
 
 agents:
-  min_matches: 3
+  min_matches: 2
   match:
-  - cloud_region: regex(.*-west-.*)
+  - cloud_provider: one_of(aws, gcp)
   - type: global

--- a/synth_tools/matchers.py
+++ b/synth_tools/matchers.py
@@ -93,12 +93,13 @@ class PropertyMatcher(Matcher):
                 return False
             if hasattr(obj, k):
                 obj = getattr(obj, k)
-            elif k in obj:  # type: ignore
-                obj = obj[k]  # type: ignore
             else:
-                log.debug("%s: object: does not have property '%s'", self.__class__.__name__, self.key)
-                log.debug("%s: ret '%s'", self.__class__.__name__, False)
-                return False
+                try:
+                    obj = obj[k]  # type: ignore
+                except (KeyError, TypeError):
+                    log.debug("%s: object: does not have property '%s'", self.__class__.__name__, self.key)
+                    log.debug("%s: ret '%s'", self.__class__.__name__, False)
+                    return False
         if isinstance(obj, Enum):
             v = obj.value
         else:


### PR DESCRIPTION
Gracefully handle misconfigured matchers (instead of throwing exception).