### PR TITLE
Remove notification channels from test config

### DIFF
--- a/data/ip_test.yaml
+++ b/data/ip_test.yaml
@@ -4,7 +4,7 @@ test:
   period: 60
   family: IP_FAMILY_DUAL
   labels: [synth_tools_test]
-  notification_channels: [109, 110]
+  notification_channels: []
   ping:
     port: 80
     protocol: tcp


### PR DESCRIPTION
Notification channels must exist before they can be used in a test config.