### PR TITLE
Fix bug in `ping.timeout` fixup

### DIFF
--- a/synth_tools/test_factory.py
+++ b/synth_tools/test_factory.py
@@ -510,7 +510,7 @@ def set_common_test_params(test: SynTest, cfg: dict, fail: Callable[[str], None]
         test.status = TestStatus(cfg["status"])
     # fixup ping timeout
     if hasattr(test.settings, "ping"):
-        if test.settings.ping.timeout >= test.settings.period:
+        if test.settings.ping.timeout >= test.settings.period * 1000:
             log.debug(
                 "set_common_test_params: test: '%s' ping.timeout (%d) > period (%d)",
                 test.name,


### PR DESCRIPTION
Need to compare same units (timeout -> ms, period -> seconds) :-/.