### PR TITLE
Support randomization of target and/or agent selection

### DIFF
--- a/data/ip_test.yaml
+++ b/data/ip_test.yaml
@@ -17,6 +17,7 @@ targets:
 
 agents:
   max_matches: 1
+  randomize: true
   match:
     - status: AGENT_STATUS_OK
     - family: one_of(IP_FAMILY_DUAL, IP_FAMILY_V6)

--- a/data/network_grid_test.yaml
+++ b/data/network_grid_test.yaml
@@ -4,6 +4,8 @@ test:
   period: 60
 
 targets:
+  max_matches: 10
+  randomize: True
   match:
     devices:
     - site.site_name: Ashburn DC3

--- a/synth_tools/test_factory.py
+++ b/synth_tools/test_factory.py
@@ -197,10 +197,12 @@ class AddressSelector:
 def address_targets(api: APIs, cfg: Dict[str, Any], fail: Callable[[str], None] = _fail) -> Set[str]:
     max_targets: Optional[int] = cfg.get("max_matches")
     min_targets: int = cfg.get("min_matches", 1)
+    randomize = cfg.get("randomize", False)
+    log.debug("address_targets: min_targets: %s, max_targets: %s, randomize: %s", min_targets, max_targets, randomize)
     targets: Set[str] = set()
 
     def add_target(a) -> bool:
-        if max_targets is None or len(targets) < max_targets:
+        if randomize or max_targets is None or len(targets) < max_targets:
             targets.add(a)
             return True
         else:
@@ -241,7 +243,9 @@ def address_targets(api: APIs, cfg: Dict[str, Any], fail: Callable[[str], None] 
         for a in address_selector.device_addresses(d):
             if not add_target(a):
                 return targets
-        if (max_targets is None or len(targets) < max_targets) and address_selector.has_interface_extractors:
+        if (
+            randomize or max_targets is None or len(targets) < max_targets
+        ) and address_selector.has_interface_extractors:
             for i in api.mgmt.devices.interfaces.get_all(d.id):
                 if interface_matcher.match(i):
                     for a in address_selector.interface_addresses(i):
@@ -250,7 +254,11 @@ def address_targets(api: APIs, cfg: Dict[str, Any], fail: Callable[[str], None] 
 
     if len(targets) < min_targets:
         fail(f"Only {len(targets)} matched, {min_targets} required")
-    return targets
+    if randomize and max_targets and len(targets) > max_targets:
+        log.debug("address_targets: selecting %d random targets our of %d candidates", max_targets, len(targets))
+        return set(random.sample(list(targets), max_targets))
+    else:
+        return targets
 
 
 def url_targets(_: APIs, cfg: Dict[str, Any], fail: Callable[[str], None] = _fail) -> Set[str]:
@@ -314,7 +322,7 @@ def _get_agents(
     )
     if len(agents) < min_agents:
         fail(f"Matched {len(agents)} agents, {min_agents} required")
-    if randomize:
+    if max_agents and randomize and len(agents) > max_agents:
         return set(random.sample(list(agents), max_agents if max_agents else len(agents)))
     else:
         return agents


### PR DESCRIPTION
Adding support for `randomize` option in the `match` section allowing to select random
sample of `max_matches` entries out of matching targets or agents.