### PR TITLE
Improved warning message

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Maximum and minimum number of matched targets of agents  can be specified using:
 `max_matches: <MAX>` or `min_matches: <MIN>` directives in corresponding `targets` or `agents` section.
 If less than `min_targets` matches test creation fails. If more than `max_matches` targets or agents match only
 first `max_matches` objects are used. At least 1 agent is required for any test (except for `network_mesh`).
+Randomization of selected targets or agents is possible using the `randomize: True` option. This option has effect only
+if `max_matches` is specified and number of matching targets or agents is greater than `max_targets`.
 
 Example:
 ```yaml

--- a/synth_tools/core.py
+++ b/synth_tools/core.py
@@ -100,12 +100,12 @@ class TestResults:
                 )
                 e["agents"].append(a)
                 for task in agent["tasks"]:
-                    for task_type in ("ping", "http", "dns"):
+                    for task_type in ("ping", "http", "dns", "dnssec", "page_load"):
                         if task_type in task:
                             break
                     else:
                         tasks = ",".join(self.test.configured_tasks)  # type: ignore
-                        log.error("No data for any of test tasks (%s) in results", tasks)
+                        log.warning("agent_id: %s - no results at: %s", a["id"], e["time"])
                         continue
                     td = task[task_type]
                     if not td["target"]:


### PR DESCRIPTION
Changed message printed when no task results are available for an agent from ERROR to WARNING and added timestamp to the text.