### PR TITLE
Add activate-details agent command

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ build>=0.7.0
 click == 8.0.1
 inflection == 0.5.1
 kentik-api >= 1.0.0
-pyyaml<6.0.0,>=5.3.1
+pyyaml>=5.3.1
 texttable == 1.6.4
 typer == 0.4.0
 validators == 0.18.2

--- a/synth_tools/commands/agents.py
+++ b/synth_tools/commands/agents.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Optional
 
 import typer
@@ -18,6 +19,19 @@ def _get_agent_by_id(api: KentikSynthClient, agent_id: str) -> dict:
         else:
             fail(f"{exc}")
     return {}  # never reached, because fail function (or other exception) terminates the app
+
+
+def _get_agents_by_alias(api: KentikSynthClient, agent_alias: str) -> List[dict]:
+    try:
+        matches = []
+        agents = api.agents
+        for a in agents:
+            if a["alias"] == agent_alias:
+                matches.append(a)
+        return matches
+    except KentikAPIRequestError as exc:
+        fail(f"{exc}")
+    return []
 
 
 @agents_app.command("list")
@@ -111,6 +125,44 @@ def activate_agent(
             typer.echo(f"id: {i} FAILED to activate (status: {a['status']}")
         else:
             typer.echo(f"id: {i} agent activated")
+
+
+@agents_app.command("activate-details")
+def activate_agent_details(
+        ctx: typer.Context,
+        agent_alias: str,
+        site_id: str,
+        private_ips: List[str],
+) -> None:
+    """
+    Activate pending agent
+    """
+    api = get_api(ctx)
+    agents = _get_agents_by_alias(api.syn, agent_alias)
+    if not len(agents):
+        fail(f"Agent alias {agent_alias} not found")
+    elif len(agents) > 1:
+        fail(f"Agent alias {agent_alias} matches multiple agents: {agents}")
+    agent = agents[0]
+    if agent["status"] != "AGENT_STATUS_WAIT":
+        typer.echo(f"agent not pending (status: {agent['status']}), continuing anyway")
+    agent["status"] = "AGENT_STATUS_OK"
+    agent["siteId"] = site_id
+    md = agent["metadata"]
+    md["privateIpv4Addresses"] = []
+    md["privateIpv6Addresses"] = []
+    for ip in private_ips:
+        if ":" in ip:
+            md["privateIpv6Addresses"].append({"value": ip})
+        else:
+            md["privateIpv4Addresses"].append({"value": ip})
+    md.pop("publicIpv4Addresses", None)
+    md.pop("publicIpv6Addresses", None)
+    typer.echo(json.dumps({"agent":agent}))
+    a = api_request(api.syn.update_agent, "AgentUpdate", agent["id"], agent)
+    if a["status"] != "AGENT_STATUS_OK":
+        fail(f"FAILED to activate agent (status: {agent['status']}")
+    typer.echo(f"agent activated!")
 
 
 @agents_app.command("deactivate")

--- a/synth_tools/commands/agents.py
+++ b/synth_tools/commands/agents.py
@@ -129,10 +129,10 @@ def activate_agent(
 
 @agents_app.command("activate-details")
 def activate_agent_details(
-        ctx: typer.Context,
-        agent_alias: str,
-        site_id: str,
-        private_ips: List[str],
+    ctx: typer.Context,
+    agent_alias: str,
+    site_id: str,
+    private_ips: List[str],
 ) -> None:
     """
     Activate pending agent
@@ -158,7 +158,7 @@ def activate_agent_details(
             md["privateIpv4Addresses"].append({"value": ip})
     md.pop("publicIpv4Addresses", None)
     md.pop("publicIpv6Addresses", None)
-    typer.echo(json.dumps({"agent":agent}))
+    typer.echo(json.dumps({"agent": agent}))
     a = api_request(api.syn.update_agent, "AgentUpdate", agent["id"], agent)
     if a["status"] != "AGENT_STATUS_OK":
         fail(f"FAILED to activate agent (status: {agent['status']}")


### PR DESCRIPTION
Allows an agent to be activated with a given site and private addrs

For example:
```
synth_ctl agent activate-details myagent 1234 10.1.2.3
agent activated!
```